### PR TITLE
Update Requires compat version to latest

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1"
-Requires = "0.5"
+Requires = "1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Currently MetaArrays unnecessarily restricts Requires compat to an old version. This forces many packages to downgrade when using MetaArrays. Suggest updating compat version to latest.