### PR TITLE
Customize Base.showarg

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,4 +248,18 @@ testunion(x) = :notrange
     @test all(zero(x) .== 0)
     @test all(one(x) .== 1)
   end
+
+  @testset "summary" begin
+      iobuf = IOBuffer()
+      a = zeros(3,3)
+
+      Base.showarg(iobuf, a, false)
+      sparent = String(take!(iobuf))
+
+      for kws in [(val = 4,), (a = 3, b = 5)]
+          b = meta(a; kws...);
+          summary(iobuf, b)
+          @test String(take!(iobuf)) == "3×3 MetaArray($sparent, $(keys(kws)))"
+      end
+  end
 end


### PR DESCRIPTION
Before this PR:

```julia
julia> a = zeros(3,3);

julia> b = meta(a, x = 3, y = 10, z = 5);

julia> summary(b)
"3×3 MetaArray{Array{Float64,2},NamedTuple{(:x, :y, :z),Tuple{Int64,Int64,Int64}},Float64,2}"
```

After this PR:

```julia
julia> summary(b)
"3×3 MetaArray(::Array{Float64,2}, (:x, :y, :z))"
```

This makes the summary a bit less cluttered if `meta` has many elements.