### PR TITLE
show using summary

### DIFF
--- a/src/MetaArrays.jl
+++ b/src/MetaArrays.jl
@@ -105,15 +105,16 @@ a meta array of `T`.
 """
 const MetaUnion{T} = Union{MetaArray{<:T},T}
 
-function Base.show(io::IO, ::MIME"text/plain", x::MetaArray)
-  print(io,"MetaArray of ")
-  show(io, "text/plain", parent(x))
+function Base.show(io::IO, ::MIME"text/plain", x::MetaArray{<:AbstractRange})
+  print(io,"MetaArray(")
+  show(io, parent(x))
+  print(io, ", ", keys(getmeta(x)))
+  print(io, ")")
 end
 
 function Base.showarg(io::IO, x::MetaArray, toplevel)
-  !toplevel && print(io, "::")
   print(io, "MetaArray(")
-  Base.showarg(io, getcontents(x), false)
+  Base.showarg(io, parent(x), false)
   print(io, ", ", keys(getmeta(x)))
   print(io, ")")
 end
@@ -163,6 +164,8 @@ combine(x,::NoMetaData) = x
 combine(::NoMetaData,x) = x
 combine(::NoMetaData,::NoMetaData) = NoMetaData()
 MetaArray(meta::NoMetaData,data::AbstractArray) = error("Unexpected missing meta data")
+# Needed for ambiguity resolution
+MetaArray(meta::NoMetaData,data::MetaArray) = error("Unexpected missing meta data")
 
 # match array behavior of wrapped array (maintaining the metdata)
 Base.size(x::MetaArray) = size(parent(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,11 @@ testunion(x) = :notrange
 
 @testset "MetaArrays" begin
 
+  @testset "Constructors" begin
+      @test_throws ErrorException MetaArray(MetaArrays.NoMetaData(), rand(2,2))
+      @test_throws ErrorException MetaArray(MetaArrays.NoMetaData(), meta(rand(2,2), a = 3))
+  end
+
   @testset "MetaArray handles standard array operations" begin
     data = collect(1:10)
     x = meta(data,val=1)
@@ -249,8 +254,9 @@ testunion(x) = :notrange
   end
 
   @testset "Proper MetaArray display" begin
-    expected = "MetaArray of 1:10"
-    x = meta(1:10,val=1)
+    r = 1:10
+    x = meta(r,val=1)
+    expected = "MetaArray($(repr(r)), (:val,))"
     iobuf = IOBuffer()
     display(TextDisplay(iobuf), x)
     @test String(take!(iobuf)) == expected


### PR DESCRIPTION
Change the way `MetaArray`s are displayed to include the keys of the metadata in the summary. This is now possible as #5 is merged.

```julia
julia> meta(reshape(1:16, 4, 4), val = 3) # Uses the default array show
4×4 MetaArray(reshape(::UnitRange{Int64}, 4, 4), (:val,)):
 1  5   9  13
 2  6  10  14
 3  7  11  15
 4  8  12  16

julia> meta(1:16, val = 3) # This is a special method
MetaArray(1:16, (:val,))
```

Also fixes an ambiguity on master, now this throws an `error` instead of an ambiguity:

```julia
julia> MetaArray(MetaArrays.NoMetaData(), meta(rand(2, 2), val = 1))
ERROR: Unexpected missing meta data
```