### PR TITLE
Improve broadcasting performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tags
 lcov.info
+Manifest.toml
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MetaArrays"
 uuid = "36b8f3f0-b776-11e8-061f-1f20094e1fc8"
 authors = ["David Little <david.frank.little@gmail.com>"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"

--- a/src/MetaArrays.jl
+++ b/src/MetaArrays.jl
@@ -94,7 +94,7 @@ Return the metadata stored in `MetaArray`
 """
 getmeta(x::MetaArray) = Base.getfield(x,:meta)
 function meta(data::MetaArray;meta...)
-  MetaArray(merge(getmeta(data),meta.data), parent(data))
+  MetaArray(merge(getmeta(data), values(meta)), parent(data))
 end
 
 """
@@ -125,35 +125,33 @@ function metamerge(x::A,y::B) where {A,B}
   x == y ? y : UnknownMerge{A,B}()
 end
 
-function checkmerge(::Nothing,v::UnknownMerge{A,B}) where {A,B}
-  error("Metadata to combine is non-identical ",
+mergeerror_headtext(key) = "The field `$key` has non-identical values across metadata "
+mergeerror_headtext(::Nothing) = "Metadata to combine is non-identical "
+
+throw_mergeerror(A, B, key = nothing) = error(mergeerror_headtext(key),
         "and there is no known way to merge an object of type $A with an",
         " object of type $B. You can fix this by defining ",
         "`MetaArrays.metamerge` for these types.")
-end
-function checkmerge(k,v::UnknownMerge{A,B}) where {A,B}
-  error("The field `$k` has non-identical values across metadata ",
-        "and there is no known way to merge non-identical objects of type $A with an",
-        " object of type $B. You can fix this by defining ",
-        "`MetaArrays.metamerge` for these types.")
-end
-checkmerge(k,v) = nothing
 
 # TOOD: file an issue with julia about mis-behavior of `merge`.
-function combine(x,y)
-  result = metamerge(x,y)
-  checkmerge(nothing,result)
-  result
+function combine(x, y)
+  x_ = metamerge(x, y)
+  x_ isa UnknownMerge && throw_mergeerror(typeof(x), typeof(y))
+  x_
 end
-function combine(x::NamedTuple,y::NamedTuple)
-  result = combine_(pairs(x),iterate(pairs(x)),y)
-  for (k,v) in pairs(result); checkmerge(k,v); end
+function combine(x::NamedTuple, y::NamedTuple)
+  combine_(pairs(x), iterate(pairs(x)), y)
+end
 
-  result
-end
-combine_(x, ::Nothing, result) = result
-function combine_(x, ((key,val),state), result)
-  newval = haskey(result,key) ? metamerge(val,result[key]) : val
+@inline combine_(x, ::Nothing, result) = result
+@inline function combine_(x, ((key,val),state), result)
+  newval = if haskey(result, key)
+    x_ = metamerge(val, result[key])
+    x_ isa UnknownMerge && throw_mergeerror(typeof(val), typeof(result[key]), key)
+    x_
+  else
+    val
+  end
   entry = NamedTuple{(key,)}((newval,))
   combine_(x, iterate(x,state), merge(result,entry))
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,12 @@
+[deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+AxisArrays = "0.4"
+OffsetArrays = "1"
+StaticArrays = "1"
+Unitful = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,7 +257,7 @@ testunion(x) = :notrange
     expected = "MetaArray of 1:10"
     x = meta(1:10,val=1)
     iobuf = IOBuffer()
-    display(TextDisplay(iobuf), x)
+    show(iobuf, "text/plain", x)
     @test String(take!(iobuf)) == expected
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,7 +228,13 @@ testunion(x) = :notrange
 
   @testset "type-stability of combine" begin
     m = (; a = 1);
-    @test (@inferred MetaArrays.combine(m, m)) == m
+    # This isn't inferred on v1.0
+    x = if VERSION >= v"1.6"
+      @inferred MetaArrays.combine(m, m)
+    else
+      MetaArrays.combine(m, m)
+    end
+    @test x == m
   end
 
   @testset "Appropriate conversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,6 +226,11 @@ testunion(x) = :notrange
     @test getmeta(x) isa NamedTuple
   end
 
+  @testset "type-stability of combine" begin
+    m = (; a = 1);
+    @test (@inferred MetaArrays.combine(m, m)) == m
+  end
+
   @testset "Appropriate conversion" begin
     x = meta(1:10,val=1)
 


### PR DESCRIPTION
This PR does two things: 

1. eagerly check for merge errors
2. inline `combine_` to allow constant-propagation of keys

Together, these improve broadcasting performance somewhat.
On master
```julia
julia> a = meta(ones(4000), a=4);

julia> @btime parent($a) .+ parent($a);
  2.917 μs (2 allocations: 31.30 KiB)

julia> @btime $a .+ $a;
  4.890 μs (25 allocations: 31.94 KiB)
```

After this PR:
```julia
julia> @btime $a .+ $a;
  2.924 μs (2 allocations: 31.30 KiB)
```

There's more to be done to address #13, but this is a start.